### PR TITLE
Dependency bump for CVE-2020-8244

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"file-type": "^5.2.0",
 		"is-stream": "^1.1.0",
-		"tar-stream": "^1.5.2"
+		"tar-stream": "^2.1.4"
 	},
 	"devDependencies": {
 		"ava": "*",


### PR DESCRIPTION
Update `tar-stream` to `2.1.4` so we can update to `bl` version `4.0.3`.

The `tar-stream` breaking changes for `2.0.0` aren't formally documented, but are just [upping of the minimum Node.js version to v6](https://github.com/mafintosh/tar-stream/commit/a443b1a06ea4e7ff0b2c1345e3efb287b8ed8481).

![image](https://user-images.githubusercontent.com/283294/98400630-44e6f980-205c-11eb-9048-ce174aa44d37.png)
